### PR TITLE
examples/WGS1984Quad.xml: Fixed id to match identifier

### DIFF
--- a/schemas/tms/2.0/xml/examples/tilematrixset/WGS1984Quad.xml
+++ b/schemas/tms/2.0/xml/examples/tilematrixset/WGS1984Quad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<TileMatrixSet id="WGS1984Quad" xmlns="http://www.opengis.net/tms/2.0" xmlns:tmsc="http://www.opengis.net/tms/2.0/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/tms/2.0 ../../tilematrixset.xsd">
+<TileMatrixSet id="WorldCRS84Quad" xmlns="http://www.opengis.net/tms/2.0" xmlns:tmsc="http://www.opengis.net/tms/2.0/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/tms/2.0 ../../tilematrixset.xsd">
 	<tmsc:Title>EPSG:4326 for the World</tmsc:Title>
 	<tmsc:Identifier>WorldCRS84Quad</tmsc:Identifier>
 	<tmsc:BoundingBox crs="http://www.opengis.net/def/crs/EPSG/0/4326">


### PR DESCRIPTION
- The identifier has already been changed to, WorldCRS84Quad, so <TileMatrixSet id=... should probably match as well