### PR TITLE
Correct case for tileMatrixLimits.json schema.

### DIFF
--- a/schemas/tms/2.0/json/tileSet.json
+++ b/schemas/tms/2.0/json/tileSet.json
@@ -60,7 +60,7 @@
 					"type": "array",
 					"items":
 					{
-						"$ref": "tilematrixlimits.json"
+						"$ref": "tileMatrixLimits.json"
 					}
 				},
 				"crs": {


### PR DESCRIPTION
This change updates updates the reference to the tile matrix limits schema to use the correct case for the URL.