### PR TITLE
Remove "uri" format from tileMatrix property.

### DIFF
--- a/schemas/tms/2.0/json/tileMatrixLimits.json
+++ b/schemas/tms/2.0/json/tileMatrixLimits.json
@@ -16,7 +16,6 @@
 		"tileMatrix":
 		{
 			"type": "string",
-			"format": "uri",
 			"examples": ["5"]
 		},
 		"minTileRow":


### PR DESCRIPTION
The "uri" format is intended to be used with absolute URI (see https://json-schema.org/draft-06/json-schema-release-notes.html#formats-uri-vs-uri-reference).  It could be that this is meant to be a "uri-reference" formatted property, but I think that is unnecessary (and the schema for a [tileMatrixSet](https://github.com/opengeospatial/2D-Tile-Matrix-Set/blob/master/schemas/tms/2.0/json/tileMatrixSet.json) doesn't specify a format for the `id` property).