### PR TITLE
Require links (at least one with rel "item")

### DIFF
--- a/schemas/tms/2.0/json/tileSet.json
+++ b/schemas/tms/2.0/json/tileSet.json
@@ -6,7 +6,7 @@
 	[
 		{
 			"type": "object",
-			"required": ["dataType"],
+			"required": ["dataType", "links"],
 			"properties":
 			{
 				"title": {


### PR DESCRIPTION
[Requirement 9.E](https://docs.ogc.org/DRAFTS/20-057.html#_response_4) of the latest OGC API - Tiles draft spec says that at least one "item" type link is required:

> The tileset metadata SHALL include at least one templated link to individual tiles using the relation type "item", and the template parameters {tileMatrix}, and {tileRow} and {tileCol}. Those variables are to be substituted by their respective valid values to obtain the URL to a tile.

The `links` description in the schema ("Possible link 'rel' values are: 'dataset'...") also looks outdated (doesn't mention "item"), but I haven't changed that here (I'm still not clear on how the schema in this repo and the spec in the [ogcapi-tiles repo](https://github.com/opengeospatial/ogcapi-tiles) are related and kept in sync).