### PR TITLE
Relase Notes: 4-change-log, 5-critical, 6-substantive

### DIFF
--- a/release_notes/clause-4-change-log.adoc
+++ b/release_notes/clause-4-change-log.adoc
@@ -6,11 +6,11 @@
 * Source:
 ** Change Request (CR)
 ** GitHub Issue
-** Editor - The CDB document Editor
+** Editor - The TileMatrixSet document Editor
 ** OGC-NA - OGC Naming Authority review
 ** Public - Public Comment period
 ** SWG decision
-** User - The CDB User Community
+** User - The TileMatrixSet User Community
 ** Other
 
 * Identifier: Change Request number or issue number and pull request/commit in GitHub
@@ -47,15 +47,21 @@ See <<Clause_Critical>> for more information on critical changes and
 | GitHub | #1 | Substantive | 4 | Align with the Abstract specification Topic 22 - Core Tiling Conceptual and Logical Models for 2D Euclidean Space OGC 19-014r3 | Consistency
 | GitHub | #13 | Substantive | 5 | OWS Common dependency removed | Interoperability
 | GitHub | #12 | Substantive | 5 | Introduction of CRSType that allows for using a full WKT description as an alternative to a CRS link for a CRS definition | Interoperability
-| GitHub | #4, #5 | Critical | 6 | Adding cell size and cornerOfOrigin | Usability
-| Editor | NA | Substantive | 7 | Removing the JSON-LD due lack of interest and concerns on real use cases. It can be reintroduced at later stage | Interoperability
+| GitHub | #34 | Critical | 6 | Identifying with `uri` a well-known TileMatrixSet in the official OGC registry | Usability
+| GitHub | #5 | Critical | 6 | Replacing `topLeftCorner` by `pointOfOrigin` | Usability
+| GitHub | #30 | Critical | 6 |  Renaming `supportedCRS` to `crs` | Consistency
+| GitHub | #4, #5 | Substantive | 6 | Adding `cellSize` and `cornerOfOrigin` | Usability
+| GitHub | #18 | Substantive | 6 | Making `boundingBox` optional | Usability
+| GitHub | #18 | Substantive | 6 | Adding optional `orderedAxes` to highlight CRS axis ordering | Usability
 | Editor | NA | Critical | 7 | JSON encoding rules to derive a JSON encoding from UML | Interoperability
+| GitHub | #7 | Substantive | 7 | Removing `type` object properties | Consistency
+| Editor | NA | Substantive | 7 | Removing the JSON-LD due lack of interest and concerns on real use cases. It can be reintroduced at later stage | Interoperability
 | GitHub | #10, #11, #30 | Critical | 8 | New data model for tileset metadata that includes the TileMatrixSetLimits and replaces TileMatrixSetLink | Completeness
-| GitHub | #34 | Critical | 8 | Possibility to link to a tilematrixset defined in a external repository added | Completeness
+| GitHub | #34 | Critical | 8 | Linking to (rel: `tiling-scheme`) or embedding a TileMatrixSet definition, and identifying use of registered TileMatrixSet with `tileMatrixSetURI` | Completeness
 | GitHub | #10, #11 | Substantive | 9 | New XML and JSON encoding for tileset metadata. It could be useful for the new OGC API Tiles | Completeness
 | GitHub | #31 | Administrative  | Annex D, F | Axis order in the EuropeanETRS89_LAEAQuad TMS | Consistency
 | GitHub | #22 | Substantive | Annex E | New annex with variable width TMS definitions | Completeness
 | GitHub | #17 | Substantive | Annex G | Added example encodings of CDB variable width TMS | Completeness
 | GitHub | #26 | Substantive | Annex J | New annex with consideration for Extending TileMatrixSets for additional dimensions | Completeness
-| GitHub | #6, #7 | Administrative | All | Correction of mistakes and inconsistencies in UML , XML and JSON encodings | Consistency
+| GitHub | #6, #7 | Administrative | All | Correction of mistakes and inconsistencies in UML, XML and JSON encodings | Consistency
 |=======================================================================

--- a/release_notes/clause-5-critical.adoc
+++ b/release_notes/clause-5-critical.adoc
@@ -1,11 +1,20 @@
 [[Clause_Critical]]
 == Description of Critical Changes
 
-=== Adding cell size and corner of origin
-Cell size of a tile matrix is added to complement the existing Scale denominator of a tile matrix. They are related by the use of the standard 0.28mm pixel size so thy are complementary. Corner of origin was added to allow for bottom - left origin of the tile indices, in addition to the common top left.
+=== Identifying with `uri` a well-known TileMatrixSet in the official OGC registry
+A TileMatrixSet registered on the official OGC NA TileMatrixSets registry now identifies itself as such with a `uri` property pointing the canonical definition.
+
+=== Replacing `topLeftCorner` by `pointOfOrigin`
+The `topLeftCorner` property is replaced by `pointOfOrigin` to reflect the fact that tile matrix rows can now be counted starting from the bottom (based on the enumeration value of `cornerOfOrigin` property).
+
+=== Renaming `supportedCRS` to `crs`
+The `supportedCRS` property was renamed to the more appropriate `crs`, since it identifies the one CRS in which the TileMatrixSet is defined.
+Additionally, a new clause clarifies the compatibility between a TileSet CRS and its TileMatrixSet CRS, facilitating the re-use of common registered TileMatrixSets.
 
 === JSON encoding rules to derive a JSON encoding from UML
 Some extra rules for deriving JSON encodings from UML that results in a more natural output were introduced.
+
+As a result, some properties were renamed. For example in the JSON encoding, `identifier` was renamed to `id`, and `tileMatrix` was renamed to the plural `tileMatrices` (since its value is an array).
 
 === Data model for tileset metadata
 In version 1.0 there was a concept of TileMatrixSetLink (and data structure) designed to allow a dataset to declare the use of a tile matrix set defined elsewhere and, if needed, a limited coverage for this tile matrix set. In this standard, this concept has been extended beyond recognition into the TileSetMetadata structure that contains the metadata describing a set of tiles representing the same geospatial data and all conforming to a tile matrix set (a tileset), the limited coverage, and the suggested center point. Even if the new data structure looks different and covers more use cases, the previous functionality provided by the TileMatrixSetLink data structure is still included in the TileSetMetadata structure.
@@ -21,5 +30,7 @@ Equivalences from the old version into the new version are:
 | |
 |===
 
-=== Link to a tilematrixset defined in a external repository
-`tileMatrixSetURI` allows tileset metadata to reference an official tileMatrixSet used for a tileset. It should be used if the tilematrixset is one of the OGC NA TileMatrixSets. At least a TileMatrixSet, or a link with `rel`=tiling-scheme SHALL be provided.
+=== Linking to (rel: `tiling-scheme`) or embedding a TileMatrixSet definition, and identifying use of registered TileMatrixSet with `tileMatrixSetURI`
+A `tileMatrixSetURI` is now used for the tileset metadata to reference a TileMatrixSet registered on the official OGC NA TileMatrixSets registry.
+In addition, either a link to a TileMatrixSet (using a `rel`=tiling-scheme), or a embedded TileMatrixSet definition (for offline use cases) must be provided.
+This link can be either to an official OGC NA TileMatrixSet definition, or to the server's own local definition (e.g. at `/tileMatrixSets/{tileMatrixSetID}`).

--- a/release_notes/clause-6-substantive.adoc
+++ b/release_notes/clause-6-substantive.adoc
@@ -9,7 +9,24 @@ Significant effort has been done to align the terminology with the Abstract spec
 We removed the dependency to OWS common and imported the necessary element in the document instead: LanguageString, Description Title Keyword data elements and Bounding Box.
 
 === CRSType
-In this version of the standard, the possibility define a CRS using a full description in addition to a reference to an external CRS catalogue is introduced. For backwards compatibility, CRSType can be defaulted as a URI but in here we extend it to a union of three possibilities.
+In this version of the standard, the possibility to define a CRS using a full description in addition to a reference to an external CRS catalogue is introduced. For backwards compatibility, CRSType can be defaulted as a URI but in here we extend it to a union of three possibilities.
+
+=== Adding `cellSize` and `cornerOfOrigin`
+The `cellSize` of a tile matrix is added to complement the existing `scaleDenominator` of a tile matrix. They are related by the use of the standard 0.28mm pixel size so they are complementary. `cornerOfOrigin` was added to allow for bottom-left origin of the tile rows indices, in addition to the common top-left.
+
+=== Making `boundingBox` optional
+The `boundingBox` property was made optional, highlighting the fact that the space occupied by tiles is really defined by the `pointOfOrigin` as well as the `scaleDenominator` / `resolution`, and the `matrixWidth` and `matrixHeight` of *each* TileMatrix, not the `boundingBox` of the overall TileMatrixSet.
+Examples were updated to not define the bounding box, which should not be relied upon by clients.
+
+=== Adding optional `orderedAxes` to highlight CRS axis ordering
+An optional `orderedAxes` property can be used to highlight the axis ordering of the TileMatrixSet's CRS without having to look up the CRS definition.
+It should also help avoid mistakes where the axis ordering used for specifying the TileMatrices `pointOfOrigin` is inconsistent with the CRS axis ordering.
+However, this property cannot be used to modify the axis ordering defined by the CRS. Examples were updated to include this property.
+
+=== Removing `type` object properties
+The `type` property of the JSON encoding (e.g. `TileMatrixSetType`) were removed, as they were superfluous because wherever it was used, each property
+could only be of a s single type (no polymorphism is required). Additionnally, it was agreed that when such `type` property would be used in future specifications,
+the enumeration values would avoid a `Type` suffix.
 
 === Removing the JSON-LD
 Due to the lack of interest and concerns on real use cases the JSON-LD encoding was removed. It can be reintroduced at later stage if there is demand.


### PR DESCRIPTION
- Moved "Adding `cellSize` and `cornerOfOrigin`" from Critical to Substantive as it is not a breaking change for current 1.0 TMS definitions
- Fixed bad references from CDB Release Notes template
- Noting missing changes to TMS definitions from 1.0 to 2.0