### PR TITLE
The tileMatrix property is required in a TilePoint

### DIFF
--- a/schemas/tms/2.0/json/tilePoint.json
+++ b/schemas/tms/2.0/json/tilePoint.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft/2019-09/schema",
 	"type": "object",
-	"required": ["coordinates"],
+	"required": ["coordinates", "tileMatrix"],
 	"properties":
 	{
 		"coordinates":


### PR DESCRIPTION
[Table 20](https://docs.opengeospatial.org/DRAFTS/17-083r4.html#parts-of-tilepoint-data-structure) in the spec says that the `tileMatrix` property is required.  Assuming the spec is correct, this change suggests updating the `tilePoint.json` schema to reflect that.