### PR TITLE
rename identifier to id to avoid confusion

### DIFF
--- a/standard/sections/06-tile_matrix_set.adoc
+++ b/standard/sections/06-tile_matrix_set.adoc
@@ -343,7 +343,7 @@ image::TileMatrixSet.png[TileMatrixSet UML model]
 |===
 | Names | Definition | Data type and values | Multiplicity and use
 
-| identifier
+| id
 | Tile matrix set identifier{blank}footnote:g6[TileMatrixSet identifiers
 SHALL be unique (different) for each TileMatrixSet of a server.]
 | CodeType, as adaptation of MD_Identifier class <<iso19115>>
@@ -442,7 +442,7 @@ elements is needed to define the distribution of tiles for each scale denominato
 |===
 | Names | Definition | Data type and values | Multiplicity and use
 
-| identifier
+| id
 | Tile matrix identifier
 
 footnote:f7[The cell size of the tile can be obtained from the scaleDenominator


### PR DESCRIPTION
In TMS 2.0, the `identifier` for both the TileMatrixSet and TileMatrix class was renamed `id`. I think still having `identifier` in the doc is confusion

ref: https://docs.ogc.org/is/17-083r4/21-066r1.html#_json_encoding_rules_to_derive_a_more_natural_json_encoding_from_uml